### PR TITLE
Replacing NoStaminaFlash (doesnt exist anymore) for UppgradeFlash

### DIFF
--- a/MassFarming/MassPlant.cs
+++ b/MassFarming/MassPlant.cs
@@ -87,7 +87,7 @@ namespace MassFarming
 
                 if (!hasStamina)
                 {
-                    Hud.instance.StaminaBarNoStaminaFlash();
+                    Hud.instance.StaminaBarUppgradeFlash();
                     return;
                 }
 
@@ -249,7 +249,7 @@ namespace MassFarming
                 }
                 else if (!MassFarming.IgnoreStamina.Value && currentStamina < tool.m_shared.m_attack.m_attackStamina)
                 {
-                    Hud.instance.StaminaBarNoStaminaFlash();
+                    Hud.instance.StaminaBarUppgradeFlash();
                     invalid = true;
                 }
                 else if (!(bool)m_noPlacementCostField.GetValue(__instance) && !__instance.HaveRequirements(_fakeResourcePiece, Player.RequirementMode.CanBuild))


### PR DESCRIPTION
Hud.instance.StaminaBarNoStaminaFlash(); is no longer a thing on the new version.

I know you won't update your mod now (it would break it for anyone not on the mistlands beta) but maybe you would want to create a new build for it? I hope this helps you somewhat!