### PR TITLE
More grid options.

### DIFF
--- a/MassFarming/MassFarming.cs
+++ b/MassFarming/MassFarming.cs
@@ -12,7 +12,8 @@ namespace MassFarming
         public static ConfigEntry<KeyboardShortcut> MassActionHotkey { get; private set; }
         public static ConfigEntry<KeyboardShortcut> ControllerPickupHotkey { get; private set; }
         public static ConfigEntry<float> MassInteractRange { get; private set; }
-        public static ConfigEntry<int> PlantGridSize { get; private set; }
+        public static ConfigEntry<int> PlantGridWidth { get; private set; }
+        public static ConfigEntry<int> PlantGridLength { get; private set; }
         public static ConfigEntry<bool> IgnoreStamina { get; private set; }
         public static ConfigEntry<bool> IgnoreDurability { get; private set; }
 
@@ -23,7 +24,8 @@ namespace MassFarming
 
             MassInteractRange = Config.Bind("Pickup", nameof(MassInteractRange), 5f, "Range of auto-pickup.");
 
-            PlantGridSize = Config.Bind("Plant", nameof(PlantGridSize), 5, "Grid size of auto-plant. Reccomend odd-number, default is '5' so (5x5).");
+            PlantGridWidth = Config.Bind("Plant", nameof(PlantGridWidth), 5, "Grid width of auto-plant. Recommend odd-number, default is '5' so (5x5).");
+            PlantGridLength = Config.Bind("Plant", nameof(PlantGridLength), 5, "Grid wength of auto-plant. Recommend odd-number, default is '5' so (5x5).");
             IgnoreStamina = Config.Bind("Plant", nameof(IgnoreStamina), false, "Ignore stamina requirements when planting extra rows.");
             IgnoreDurability = Config.Bind("Plant", nameof(IgnoreDurability), false, "Ignore durability when planting extra rows.");
 

--- a/MassFarming/MassFarming.cs
+++ b/MassFarming/MassFarming.cs
@@ -16,6 +16,8 @@ namespace MassFarming
         public static ConfigEntry<int> PlantGridLength { get; private set; }
         public static ConfigEntry<bool> IgnoreStamina { get; private set; }
         public static ConfigEntry<bool> IgnoreDurability { get; private set; }
+        public static ConfigEntry<bool> GridAnchorWidth { get; private set; }
+        public static ConfigEntry<bool> GridAnchorLength { get; private set; }
 
         public void Awake()
         {
@@ -24,10 +26,12 @@ namespace MassFarming
 
             MassInteractRange = Config.Bind("Pickup", nameof(MassInteractRange), 5f, "Range of auto-pickup.");
 
-            PlantGridWidth = Config.Bind("Plant", nameof(PlantGridWidth), 5, "Grid width of auto-plant. Recommend odd-number, default is '5' so (5x5).");
-            PlantGridLength = Config.Bind("Plant", nameof(PlantGridLength), 5, "Grid wength of auto-plant. Recommend odd-number, default is '5' so (5x5).");
+            PlantGridWidth = Config.Bind("PlantGrid", nameof(PlantGridWidth), 5, "Grid width of auto-plant. Recommend odd-number, default is '5' so (5x5).");
+            PlantGridLength = Config.Bind("PlantGrid", nameof(PlantGridLength), 5, "Grid length of auto-plant. Recommend odd-number, default is '5' so (5x5).");
             IgnoreStamina = Config.Bind("Plant", nameof(IgnoreStamina), false, "Ignore stamina requirements when planting extra rows.");
             IgnoreDurability = Config.Bind("Plant", nameof(IgnoreDurability), false, "Ignore durability when planting extra rows.");
+            GridAnchorWidth = Config.Bind("PlantGrid", nameof(GridAnchorWidth), true, "Planting grid anchor point (width). Default is 'enabled' so the grid will extend left and right from the crosshairs. Disable to set the anchor to the side of the grid. Disable both anchors to set to corner.");
+            GridAnchorLength = Config.Bind("PlantGrid", nameof(GridAnchorLength), true, "Planting grid anchor point (length). Default is 'enabled' so the grid will extend forward and backward from the crosshairs. Disable to set the anchor to the side of the grid. Disable both anchors to set to corner.");
 
             Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly(), null);
         }

--- a/MassFarming/MassPlant.cs
+++ b/MassFarming/MassPlant.cs
@@ -130,18 +130,18 @@ namespace MassFarming
         private static List<Vector3> BuildPlantingGridPositions(Vector3 originPos, Plant placedPlant, Quaternion rotation)
         {
             var plantRadius = placedPlant.m_growRadius * 2;
-            int halfGrid = MassFarming.PlantGridSize.Value / 2;
+            int halfGrid = MassFarming.PlantGridWidth.Value / 2;
 
-            List<Vector3> gridPositions = new List<Vector3>(MassFarming.PlantGridSize.Value * MassFarming.PlantGridSize.Value);
+            List<Vector3> gridPositions = new List<Vector3>(MassFarming.PlantGridWidth.Value * MassFarming.PlantGridLength.Value);
             Vector3 left = rotation * Vector3.left * plantRadius;
             Vector3 forward = rotation * Vector3.forward * plantRadius;
-            Vector3 gridOrigin = originPos - (forward * halfGrid) - (left * halfGrid);
+            Vector3 gridOrigin = originPos - (left * halfGrid);
 
             Vector3 newPos;
-            for (var x = 0; x < MassFarming.PlantGridSize.Value; x++)
+            for (var x = 0; x < MassFarming.PlantGridLength.Value; x++)
             {
                 newPos = gridOrigin;
-                for (var z = 0; z < MassFarming.PlantGridSize.Value; z++)
+                for (var z = 0; z < MassFarming.PlantGridWidth.Value; z++)
                 {
                     newPos.y = ZoneSystem.instance.GetGroundHeight(newPos);
                     gridPositions.Add(newPos);
@@ -264,7 +264,7 @@ namespace MassFarming
 
         private static bool EnsureGhostsBuilt(Player player)
         {
-            var requiredSize = MassFarming.PlantGridSize.Value * MassFarming.PlantGridSize.Value;
+            var requiredSize = MassFarming.PlantGridWidth.Value * MassFarming.PlantGridLength.Value;
             bool needsRebuild = !_placementGhosts[0] || _placementGhosts.Length != requiredSize;
             if (needsRebuild) 
             {

--- a/MassFarming/MassPlant.cs
+++ b/MassFarming/MassPlant.cs
@@ -130,12 +130,19 @@ namespace MassFarming
         private static List<Vector3> BuildPlantingGridPositions(Vector3 originPos, Plant placedPlant, Quaternion rotation)
         {
             var plantRadius = placedPlant.m_growRadius * 2;
-            int halfGrid = MassFarming.PlantGridWidth.Value / 2;
 
             List<Vector3> gridPositions = new List<Vector3>(MassFarming.PlantGridWidth.Value * MassFarming.PlantGridLength.Value);
             Vector3 left = rotation * Vector3.left * plantRadius;
             Vector3 forward = rotation * Vector3.forward * plantRadius;
-            Vector3 gridOrigin = originPos - (left * halfGrid);
+            Vector3 gridOrigin = originPos;
+            if (MassFarming.GridAnchorLength.Value)
+            {
+                gridOrigin -= forward * (MassFarming.PlantGridLength.Value / 2);
+            }
+            if (MassFarming.GridAnchorWidth.Value)
+            {
+                gridOrigin -= left * (MassFarming.PlantGridWidth.Value / 2);
+            }
 
             Vector3 newPos;
             for (var x = 0; x < MassFarming.PlantGridLength.Value; x++)


### PR DESCRIPTION
I tend to plant my crops in rows rather than square grids so I thought being able to set the length and width of the grid would be a handy feature. 
I noticed another users had requested this feature on nexusmods as well: https://forums.nexusmods.com/index.php?/topic/9773013-massfarming/page-11#entry102055938

When implementing the changes I realized that the anchor point of the grid might need to change if the grid wasn't square, but I didn't want to mess with the default functionality that users are familiar with. I added some options to set the anchor to the side or corner of the placement grid to give users the option if they need it.