### PR TITLE
Making masspickup work without hotkeys if they're unset

### DIFF
--- a/MassFarming/MassFarming.cs
+++ b/MassFarming/MassFarming.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace MassFarming
 {
-    [BepInPlugin("xeio.MassFarming", "MassFarming", "1.9")]
+    [BepInPlugin("xeio.MassFarming", "MassFarming", "1.10")]
     public class MassFarming : BaseUnityPlugin
     {
         public static ConfigEntry<KeyboardShortcut> MassActionHotkey { get; private set; }

--- a/MassFarming/MassPickup.cs
+++ b/MassFarming/MassPickup.cs
@@ -24,7 +24,17 @@ namespace MassFarming
                 return;
             }
 
-            if (!Input.GetKey(MassFarming.ControllerPickupHotkey.Value.MainKey) && !Input.GetKey(MassFarming.MassActionHotkey.Value.MainKey))
+            var controllerKey = MassFarming.ControllerPickupHotkey.Value.MainKey;
+			var controllerKeyEmpty = controllerKey == KeyCode.None;
+            var controllerPressed = Input.GetKey(controllerKey);
+            var controllerOk = controllerKeyEmpty || controllerPressed;
+
+            var keyboardKey = MassFarming.MassActionHotkey.Value.MainKey;
+            var keyboardKeyEmpty = keyboardKey == KeyCode.None;
+            var keyboardPressed = Input.GetKey(keyboardKey);
+            var keyboardOk = keyboardKeyEmpty || keyboardPressed;
+
+			if (!controllerOk && !keyboardOk)
             {
                 //Hotkey required
                 return;


### PR DESCRIPTION
Right now if you unset/clear the shortcut configurations, you're basically disabling the masspickup feature.

My change makes that, if you unset/clear it, it'll masspickup everytime (so if you want do disable it, just put a key you'll never hit, lol).